### PR TITLE
Add: Chinese translations of aiter(), all() and anext() docs

### DIFF
--- a/docs/zh/builtins/aiter.md
+++ b/docs/zh/builtins/aiter.md
@@ -1,0 +1,119 @@
+---
+source_sha: f1a1cdf5164fe4494e87ed868f67429ccba7e2c329e36cd0b820142d360f510a
+translated: machine
+---
+
+# aiter() 函数
+
+`aiter()` 函数从异步可迭代对象中返回一个异步迭代器。
+
+## 复杂度参考
+
+| 操作 | 时间 | 空间 | 备注 |
+|------|------|-------|-------|
+| `aiter()` | O(1) | O(1) | 创建迭代器 |
+| `__aiter__()` | O(1) | O(1) | 在可迭代对象上调用 |
+
+## 基本用法
+
+### 创建异步迭代器
+
+```python
+import asyncio
+
+async def async_generator():
+    for i in range(3):
+        yield i
+
+async def main():
+    # Create async iterator - O(1)
+    async_iter = aiter(async_generator())
+    
+    # Iterate
+    value = await async_iter.__anext__()
+    print(value)  # 0
+
+asyncio.run(main())
+```
+
+### 从异步可迭代对象获取
+
+```python
+import asyncio
+
+class AsyncIterable:
+    def __aiter__(self):
+        return AsyncIterator()
+
+class AsyncIterator:
+    def __init__(self):
+        self.count = 0
+    
+    async def __anext__(self):
+        if self.count >= 3:
+            raise StopAsyncIteration
+        self.count += 1
+        return self.count
+
+async def main():
+    # Get iterator from iterable - O(1)
+    iterator = aiter(AsyncIterable())
+    
+    # Use with async for
+    async for value in iterator:
+        print(value)  # 1, 2, 3
+
+asyncio.run(main())
+```
+
+## 配合 async for 使用
+
+```python
+import asyncio
+
+async def fetch_data(urls):
+    """Simulate async data fetching."""
+    for url in urls:
+        await asyncio.sleep(0.1)
+        yield f"Data from {url}"
+
+async def main():
+    urls = ["url1", "url2", "url3"]
+    
+    # aiter is implicit in async for
+    async for data in fetch_data(urls):
+        print(data)
+
+asyncio.run(main())
+```
+
+## 与 iter() 的比较
+
+```python
+import asyncio
+
+# iter() - synchronous iterator - O(1)
+def sync_generator():
+    yield 1
+    yield 2
+
+sync_iter = iter(sync_generator())
+print(next(sync_iter))  # Works synchronously
+
+# aiter() - asynchronous iterator - O(1)
+async def async_generator():
+    yield 1
+    yield 2
+
+async def main():
+    async_iter = aiter(async_generator())
+    print(await async_iter.__anext__())  # Must be awaited
+
+asyncio.run(main())
+```
+
+## 相关函数
+
+- [anext() 函数](anext.md) - 从异步迭代器获取下一个元素
+- [iter() 函数](../builtins/iter.md) - 同步迭代器
+- [next() 函数](../builtins/next.md) - 获取下一个同步元素

--- a/docs/zh/builtins/all.md
+++ b/docs/zh/builtins/all.md
@@ -1,0 +1,226 @@
+---
+source_sha: 320ab71a8582ba423db896cd3827ab3721ab7052df231a69351e224a5dd031da
+translated: machine
+---
+
+# all() 函数的复杂度
+
+如果可迭代对象中的所有元素都为真（或可迭代对象为空），`all()` 函数返回 `True`。
+
+## 复杂度分析
+
+| 情况 | 时间 | 空间 | 备注 |
+|------|------|-------|-------|
+| 所有元素均为真 | O(n) | O(1) | 必须检查所有元素 |
+| 提前退出（发现假值） | O(k) | O(1) | k = 第一个假值的位置 |
+| 空可迭代对象 | O(1) | O(1) | 立即返回 True |
+
+## 基本用法
+
+### 检查是否全为真
+
+```python
+# O(n) - must check all items
+numbers = [1, 2, 3, 4, 5]
+result = all(numbers)  # True - all truthy
+
+# Early exit - O(k) where k = position of False
+numbers = [1, 2, 0, 4, 5]
+result = all(numbers)  # False - stops at 0
+
+# Empty iterable
+result = all([])  # True - all zero items are truthy
+```
+
+### 配合条件使用
+
+```python
+# O(n) where each predicate is O(1)
+numbers = [1, 2, 3, 4, 5]
+result = all(x > 0 for x in numbers)  # True
+
+# Early exit - O(k) where k = position of first failure
+result = all(x > 2 for x in numbers)  # False - stops at 1
+```
+
+## 性能模式
+
+### 短路求值
+
+```python
+# ✅ O(1) - stops immediately at first falsy
+checks = [lambda: False, expensive_function, expensive_function]
+result = all(check() for check in checks)
+# expensive_function() is never called
+
+# ❌ O(n) - evaluates all
+result = all([False] + [expensive_function() for _ in range(1000)])
+# Calls expensive_function() 1000 times
+
+# ✅ O(k) - generator stops when predicate first fails
+result = all(x < 100 for x in range(1000000))
+# Stops after checking 100 items
+```
+
+### 生成器效率
+
+```python
+# O(n) - lazy evaluation with early exit
+large_list = range(10**9)
+result = all(x < 100 for x in large_list)
+# O(100) - stops after checking 100 items
+
+# vs list comprehension
+result = all([x < 100 for x in range(10**9)])
+# O(10^9) - creates entire list first
+```
+
+## 常见模式
+
+### 数据校验
+
+```python
+# O(n*k) - validate all items
+def validate_data(items):
+    return all(isinstance(item, int) for item in items)
+
+# O(n) early exit if any item is invalid
+valid = validate_data([1, 2, 3, 4, 5])  # True
+valid = validate_data([1, 2, "three", 4, 5])  # False - stops at "three"
+```
+
+### 检查条件
+
+```python
+# O(n) - check all items meet condition
+numbers = [2, 4, 6, 8, 10]
+all_even = all(x % 2 == 0 for x in numbers)  # True
+
+# Early exit
+numbers = [2, 4, 5, 8, 10]
+all_even = all(x % 2 == 0 for x in numbers)  # False - stops at 5
+```
+
+### 空序列处理
+
+```python
+# True for empty sequences
+all([])  # True
+all(())  # True
+all(x > 0 for x in [])  # True
+
+# Useful for "default to true" logic
+result = all(condition(x) for x in items)  # True if items is empty
+```
+
+## 与 any() 的比较
+
+```python
+# all() - True if all are truthy
+all([True, True, True])     # True
+all([True, False, True])    # False
+all([])                     # True
+
+# any() - True if any are truthy
+any([False, False, False])  # False
+any([False, True, False])   # True
+any([])                     # False
+```
+
+## 边界情况
+
+### 空可迭代对象
+
+```python
+# O(1) - returns True immediately
+all([])  # True
+all(())  # True
+all(set())  # True
+all(x for x in [])  # True
+
+# This is mathematically correct (vacuous truth)
+# "All members of the empty set satisfy any property"
+```
+
+### 单个元素
+
+```python
+# O(1) - checks one item
+all([True])   # True
+all([False])  # False
+all([1])      # True - truthy
+all([0])      # False - falsy
+```
+
+### 不同类型
+
+```python
+# O(n) - checks truthiness of any type
+all([1, "hello", [1, 2], {"key": "value"}])  # True - all truthy
+
+all([1, "", [1, 2], {"key": "value"}])  # False - "" is falsy
+```
+
+## 性能考量
+
+### 与循环的比较
+
+```python
+# all() - O(n), optimized, readable
+result = all(x > 0 for x in numbers)
+
+# Manual loop - O(n) same complexity
+result = True
+for x in numbers:
+    if not (x > 0):
+        result = False
+        break
+
+# all() is preferred - cleaner and same performance
+```
+
+### 与 any() 的用法选择
+
+```python
+# Check if any item fails condition
+numbers = [1, 2, 3, 4, 5]
+
+# ✅ Clear intent - all pass condition
+all(x > 0 for x in numbers)  # True
+
+# ❌ Confusing - any fail condition
+any(not (x > 0) for x in numbers)  # False
+
+# ❌ Confusing - all fail condition
+not any(x > 0 for x in numbers)  # False
+
+# Use all() when checking "all meet condition"
+# Use any() when checking "any meets condition"
+```
+
+## 最佳实践
+
+✅ **推荐**：
+
+- 用 `all()` 检查是否所有元素都满足条件
+- 配合生成器表达式实现惰性求值
+- 记住 `all([])` 返回 `True`（空真）
+- 对开销大的检查利用短路求值
+
+❌ **避免**：
+
+- 用推导式创建列表（应使用生成器）
+- 条件中不必要的嵌套
+- 只检查单个元素时使用 `all()`
+
+## 相关函数
+
+- **[any()](any.md)** - 检查是否存在为真的元素
+- **[filter()](filter.md)** - 按谓词过滤元素
+- **[all() with min()](max.md)** - 组合使用操作
+
+## 版本说明
+
+- **Python 2.x**：提供基本功能
+- **Python 3.x**：行为相同
+- **Python 3.8+**：优化可能提升性能

--- a/docs/zh/builtins/anext.md
+++ b/docs/zh/builtins/anext.md
@@ -1,0 +1,146 @@
+---
+source_sha: 682f753d52a44f1d1bbc5e4beb31681206169e63d2e64f3a7148bee1a7a2e8a9
+translated: machine
+---
+
+# anext() 函数
+
+`anext()` 函数从异步迭代器中返回下一个元素。
+
+## 复杂度参考
+
+| 操作 | 时间 | 空间 | 备注 |
+|------|------|-------|-------|
+| `anext()` 调用 | O(1) | O(1) | 迭代器协议调用 |
+| 等待结果 | O(k) | O(1) | k = 异步生成器的计算耗时 |
+| 带默认值 | O(k) | O(1) | 迭代耗尽时返回默认值 |
+
+<!-- 注意：复杂度取决于异步生成器内部执行的操作，而不是 anext() 本身 -->
+
+## 基本用法
+
+### 获取下一个异步元素
+
+```python
+import asyncio
+
+async def async_generator():
+    for i in range(3):
+        yield i
+
+async def main():
+    async_iter = aiter(async_generator())
+    
+    # Get next item - O(k) where k = async iterator work for this step
+    value = await anext(async_iter)
+    print(value)  # 0
+    
+    value = await anext(async_iter)
+    print(value)  # 1
+
+asyncio.run(main())
+```
+
+### 使用默认值
+
+```python
+import asyncio
+
+async def async_generator():
+    yield 1
+    yield 2
+    # Iterator exhausted after
+
+async def main():
+    async_iter = aiter(async_generator())
+    
+    print(await anext(async_iter))  # 1
+    print(await anext(async_iter))  # 2
+    
+    # Default when exhausted - O(1) once iterator is exhausted
+    value = await anext(async_iter, "END")
+    print(value)  # "END"
+
+asyncio.run(main())
+```
+
+### 不带默认值（抛出异常）
+
+```python
+import asyncio
+
+async def async_generator():
+    yield 1
+
+async def main():
+    async_iter = aiter(async_generator())
+    
+    print(await anext(async_iter))  # 1
+    
+    try:
+        # No default - raises StopAsyncIteration when exhausted (O(1) at exhaustion)
+        print(await anext(async_iter))
+    except StopAsyncIteration:
+        print("Iterator exhausted")
+
+asyncio.run(main())
+```
+
+## 实际示例
+
+```python
+import asyncio
+
+async def fetch_items(items):
+    for item in items:
+        await asyncio.sleep(0.1)  # Simulate async work
+        yield item
+
+async def main():
+    # Create async iterator - O(1)
+    iterator = aiter(fetch_items(["a", "b", "c"]))
+    
+    # Get items manually - O(k) each where k depends on iterator body
+    first = await anext(iterator)
+    print(f"First: {first}")  # First: a
+    
+    second = await anext(iterator, None)
+    print(f"Second: {second}")  # Second: b
+    
+    # Get remaining with loop
+    async for item in iterator:
+        print(f"Item: {item}")  # Item: c
+
+asyncio.run(main())
+```
+
+## 与 next() 的比较
+
+```python
+import asyncio
+
+# next() - synchronous - O(1)
+def sync_gen():
+    yield 1
+    yield 2
+
+sync_iter = iter(sync_gen())
+print(next(sync_iter))  # Synchronous
+
+# anext() - asynchronous - O(1) call, awaiting depends on generator
+async def async_gen():
+    yield 1
+    yield 2
+
+async def main():
+    async_iter = aiter(async_gen())
+    print(await anext(async_iter))  # Must await
+
+asyncio.run(main())
+```
+
+## 相关函数
+
+- [aiter() 函数](aiter.md) - 创建异步迭代器
+- [next() 函数](../builtins/next.md) - 同步的 next
+- [iter() 函数](../builtins/iter.md) - 创建同步迭代器


### PR DESCRIPTION
## What This Changes

Adds three new pages to the zh (简体中文) locale, covering the async-iterator
builtins and `all()`:

- `docs/zh/builtins/aiter.md` — aiter() (d7991fd)
- `docs/zh/builtins/all.md` — all(), incl. short-circuit and generator
  performance patterns (096eb92)
- `docs/zh/builtins/anext.md` — anext(), incl. default-value and exception
  behaviour (f2f48eb)

Each page mirrors the English source and records its `source_sha` in front
matter, so the translation validator tracks staleness automatically.

## Type of Change

- [x] New content
- [ ] Bug fix
- [ ] Documentation improvement
- [ ] Structure/organization

## Related Issues

N/A